### PR TITLE
Add missing TiUIView subclass-views + reorder

### DIFF
--- a/platform/titanium/element-registry.js
+++ b/platform/titanium/element-registry.js
@@ -94,103 +94,103 @@ export function registerElement(tagName, createFactoryResolver, meta = {}) {
 /* global Ti */
 
 registerElement('activity-indicator', () => Ti.UI.createActivityIndicator, {
-	type: Ti.UI.ActivityIndicator
+	type: 'Ti.UI.ActivityIndicator'
 });
 
 registerElement('button', () => Ti.UI.createButton, {
-	type: Ti.UI.Button
+	type: 'Ti.UI.Button'
 });
 
 registerElement('button-bar', () => Ti.UI.createButtonBar, {
-	type: Ti.UI.ButtonBar
+	type: 'Ti.UI.ButtonBar'
 });
 
 registerElement('cover-flow-view', () => Ti.UI.createCoverFlowView, {
-	type: Ti.UI.CoverFlowView,
+	type: 'Ti.UI.CoverFlowView'
 });
 
 registerElement('dashboard-item', () => Ti.UI.createDashboardItem, {
-	type: Ti.UI.DashboardItem,
+	type: 'Ti.UI.DashboardItem'
 });
 
 registerElement('dashboard-view', () => Ti.UI.createDashboardView, {
-	type: Ti.UI.DashboardView,
+	type: 'Ti.UI.DashboardView'
 });
 
 registerElement('image-view', () => Ti.UI.createImageView, {
-	type: Ti.UI.ImageView
+	type: 'Ti.UI.ImageView'
 });
 
 registerElement('label', () => Ti.UI.createLabel, {
-	type: Ti.UI.Label
+	type: 'Ti.UI.Label'
 });
 
 registerElement('picker', () => Ti.UI.createPicker, {
-	type: Ti.UI.Picker
+	type: 'Ti.UI.Picker'
 });
 
 registerElement('progress-bar', () => Ti.UI.createProgressBar, {
-	type: Ti.UI.ProgressBar
+	type: 'Ti.UI.ProgressBar'
 });
 
 registerElement('refresh-control', () => Ti.UI.createRefreshControl, {
-	type: Ti.UI.RefreshControl
+	type: 'Ti.UI.RefreshControl'
 });
 
 registerElement('scrollable-view', () => Ti.UI.createScrollableView, {
-	type: Ti.UI.ScrollableView
+	type: 'Ti.UI.ScrollableView'
 });
 
 registerElement('search-bar', () => Ti.UI.createSearchBar, {
-	type: Ti.UI.SearchBar
+	type: 'Ti.UI.SearchBar'
 });
 
 registerElement('slider', () => Ti.UI.createSlider, {
-	type: Ti.UI.Slider
+	type: 'Ti.UI.Slider'
 });
 
 registerElement('switch', () => Ti.UI.createSwitch, {
-	type: Ti.UI.Switch
+	type: 'Ti.UI.Switch'
 });
 
 registerElement('text-area', () => Ti.UI.createTextArea, {
-	type: Ti.UI.TextArea
+	type: 'Ti.UI.TextArea'
 });
 
 registerElement('text-field', () => Ti.UI.createTextField, {
-	type: Ti.UI.TextField
+	type: 'Ti.UI.TextField'
 });
 
 registerElement('titanium-list-view', () => Ti.UI.createListView, {
-	type: Ti.UI.ListView
+	type: 'Ti.UI.ListView'
 });
 
 registerElement('titanium-list-section', () => Ti.UI.createListSection, {
-	type: Ti.UI.ListSection,
+	type: 'Ti.UI.ListSection',
 	skipAddToDom: true
 });
 
 registerElement('titanium-tab-group', () => Ti.UI.createTabGroup, {
-	type: Ti.UI.TabGroup
+	type: 'Ti.UI.TabGroup'
 });
 
 registerElement('titanium-tab', () => Ti.UI.createTab, {
-	type: Ti.UI.Tab
+	type: 'Ti.UI.Tab'
 });
 
 registerElement('toolbar', () => Ti.UI.createToolbar, {
-	type: Ti.UI.Toolbar
+	type: 'Ti.UI.Toolbar'
 });
 
 registerElement('view', () => Ti.UI.createView, {
-	type: Ti.UI.View
+	type: 'Ti.UI.View'
 });
 
 registerElement('web-view', () => Ti.UI.createWebView, {
-	type: Ti.UI.WebView
+	type: 'Ti.UI.WebView'
 });
 
 registerElement('window', () => Ti.UI.createWindow, {
-	type: Ti.UI.Window,
+	type: 'Ti.UI.Window',
 	skipAddToDom: true
 });


### PR DESCRIPTION
- [x] Add all views that can be added to other parent-views (excluding platform-specific views like Ti.UI.iOS, Ti.UI.Android and Ti.UI.Windows for now).
- [x] Reorder element-registration alphabetically

Q: Can we add platform-specific elements already?