### PR TITLE
feat(layout): add layout components

### DIFF
--- a/platform/titanium/runtime/components/index.js
+++ b/platform/titanium/runtime/components/index.js
@@ -1,12 +1,15 @@
+import { HorizontalLayout, VerticalLayout } from './layout/index';
 import { ItemTemplate, ListView, ListSection } from './list-view/index';
 import { default as NavigationWindow } from './navigation-window';
 import { Tab, TabGroup } from './tab/index';
 
 export default {
+	HorizontalLayout,
 	ItemTemplate,
 	ListSection,
 	ListView,
 	NavigationWindow,
 	Tab,
-	TabGroup
+	TabGroup,
+	VerticalLayout
 };

--- a/platform/titanium/runtime/components/layout/horizontal-layout.js
+++ b/platform/titanium/runtime/components/layout/horizontal-layout.js
@@ -1,0 +1,11 @@
+export default {
+    name: 'HorizontalLayout',
+
+    render(h) {
+        return h('view', {
+            attrs: {
+                layout: 'horizontal'
+            }
+        }, this.$slots.default);
+    }
+}

--- a/platform/titanium/runtime/components/layout/index.js
+++ b/platform/titanium/runtime/components/layout/index.js
@@ -1,0 +1,2 @@
+export { default as HorizontalLayout } from './horizontal-layout';
+export { default as VerticalLayout } from './vertical-layout';

--- a/platform/titanium/runtime/components/layout/vertical-layout.js
+++ b/platform/titanium/runtime/components/layout/vertical-layout.js
@@ -1,0 +1,11 @@
+export default {
+    name: 'VerticallLayout',
+
+    render(h) {
+        return h('view', {
+            attrs: {
+                layout: 'vertical'
+            }
+        }, this.$slots.default);
+    }
+}


### PR DESCRIPTION
Add simple layout components to better describe layout types in templates by allowing usage of `horizontal-layout` and `vertical-layout`.