### PR TITLE
feat(model): two-way data binding on Titanium elements

### DIFF
--- a/platform/titanium/compiler/directives/model.js
+++ b/platform/titanium/compiler/directives/model.js
@@ -1,4 +1,4 @@
-import { addHandler, addProp } from 'compiler/helpers';
+import { addHandler, addAttr, addProp } from 'compiler/helpers';
 import { genComponentModel, genAssignmentCode } from 'compiler/directives/model';
 
 import { getViewMeta, hasElement } from '../../util/registry';
@@ -7,7 +7,6 @@ export default function model (el, dir) {
 	if (el.component) {
 		genComponentModel(el, dir.value, dir.modifiers);
 	} else if (!hasElement(el.tag))	{
-		console.log(`genComponentModel ${el.tag}`);
 		genComponentModel(el, dir.value, dir.modifiers);
 	} else {
 		genDefaultModel(el, dir.value, dir.modifiers);
@@ -27,6 +26,7 @@ function genDefaultModel (el, value, modifiers) {
 	}
 
 	let code = genAssignmentCode(value, valueExpression);
+	addAttr(el, prop, value);
 	addProp(el, prop, `(${value})`);
 	addHandler(el, event, code, null, true);
 }

--- a/platform/titanium/entry-compiler.js
+++ b/platform/titanium/entry-compiler.js
@@ -1,2 +1,6 @@
+import { initializeTitaniumElements } from './util/registry';
+
+initializeTitaniumElements();
+
 export { parseComponent } from 'sfc/parser';
 export { compile, compileToFunctions } from './compiler/index';

--- a/platform/titanium/util/registry.js
+++ b/platform/titanium/util/registry.js
@@ -1,10 +1,10 @@
 import { registerTitaniumElements, TitaniumElementRegistry } from 'titanium-vdom';
 
 const elementRegistry = TitaniumElementRegistry.getInstance();
-elementRegistry.defaultViewMeta = {
+elementRegistry.defaultViewMetadata = {
     detached: false,
     model: {
-        prop: 'text',
+        prop: 'value',
         event: 'change'
     }
 };


### PR DESCRIPTION
Adds support for two-way data binding on Titanium input elements like `TextField`, `Slider`, `Switch` and so on.